### PR TITLE
Add multi-page site structure

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Contact – Your Startup</title>
+  <style>
+    body{font-family:system-ui,Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.6}
+    header{margin-bottom:24px}
+    nav a{margin-right:12px;text-decoration:none}
+    footer{margin-top:32px;font-size:.9em;color:#666}
+  </style>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="live-course.html">Live Course</a>
+      <a href="practice.html">Practice</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <h1>Contact</h1>
+    <p>Email us at <a href="mailto:you@yourdomain.com">you@yourdomain.com</a> to learn more.</p>
+  </header>
+  <footer>
+    <p>© <span id="y"></span> Your Startup</p>
+  </footer>
+  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,37 +1,43 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Welcome</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Your Startup – Affordable Maths Learning</title>
+  <meta name="description" content="Recorded + live maths classes at low cost. Instant booking & group mentoring." />
   <style>
-    body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
-    header { background: #333; color: #fff; padding: 1rem; }
-    nav a { color: #fff; margin-right: 1rem; text-decoration: none; }
-    section { padding: 2rem; }
+    body{font-family:system-ui,Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.6}
+    header{margin-bottom:24px}
+    nav a{margin-right:12px;text-decoration:none}
+    a.button{display:inline-block;padding:10px 14px;border:1px solid #222;border-radius:8px;text-decoration:none}
+    .cards{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+    .card{border:1px solid #eee;border-radius:12px;padding:16px}
+    footer{margin-top:32px;font-size:.9em;color:#666}
   </style>
 </head>
 <body>
   <header>
     <nav>
-      <a href="#home">Home</a>
-      <a href="#about">About</a>
-      <a href="#contact">Contact</a>
+      <a href="index.html">Home</a>
+      <a href="live-course.html">Live Course</a>
+      <a href="practice.html">Practice</a>
+      <a href="contact.html">Contact</a>
     </nav>
+    <h1>Affordable Online Maths Learning</h1>
+    <p>Recorded classes, every 3rd class live, question practice + video solutions. Small batches (2/4/8), instant tutor booking.</p>
+    <a class="button" href="mailto:you@yourdomain.com">Contact Us</a>
   </header>
-  <main>
-    <section id="home">
-      <h1>Welcome to my website</h1>
-      <p>This is the home section.</p>
-    </section>
-    <section id="about">
-      <h2>About</h2>
-      <p>Information about the site or person.</p>
-    </section>
-    <section id="contact">
-      <h2>Contact</h2>
-      <p>You can contact me at <a href="mailto:example@example.com">example@example.com</a>.</p>
-    </section>
-  </main>
+
+  <section class="cards">
+    <div class="card"><h3>Hybrid Course</h3><p>₹800/year per student.</p></div>
+    <div class="card"><h3>Batch (2/4/8)</h3><p>₹500 ÷ batch size per year.</p></div>
+    <div class="card"><h3>Instant Booking</h3><p>₹6 per minute.</p></div>
+    <div class="card"><h3>Group Study</h3><p>₹500 ÷ group size per session.</p></div>
+  </section>
+
+  <footer>
+    <p>© <span id="y"></span> Your Startup • <a href="/privacy.html">Privacy</a> • <a href="/terms.html">Terms</a></p>
+  </footer>
+  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
 </body>
 </html>

--- a/live-course.html
+++ b/live-course.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Live Courses – Your Startup</title>
+  <style>
+    body{font-family:system-ui,Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.6}
+    header{margin-bottom:24px}
+    nav a{margin-right:12px;text-decoration:none}
+    footer{margin-top:32px;font-size:.9em;color:#666}
+  </style>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="live-course.html">Live Course</a>
+      <a href="practice.html">Practice</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <h1>Live Courses</h1>
+    <p>Join our interactive live maths sessions to ask questions in real time and collaborate with classmates.</p>
+  </header>
+  <footer>
+    <p>© <span id="y"></span> Your Startup</p>
+  </footer>
+  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+</body>
+</html>

--- a/practice.html
+++ b/practice.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Practice – Your Startup</title>
+  <style>
+    body{font-family:system-ui,Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.6}
+    header{margin-bottom:24px}
+    nav a{margin-right:12px;text-decoration:none}
+    footer{margin-top:32px;font-size:.9em;color:#666}
+  </style>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="live-course.html">Live Course</a>
+      <a href="practice.html">Practice</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+    <h1>Practice</h1>
+    <p>Solve practice problems with video solutions and track your progress over time.</p>
+  </header>
+  <footer>
+    <p>© <span id="y"></span> Your Startup</p>
+  </footer>
+  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace single index with a richer home page and navigation links.
- Add pages for live courses, practice, and contact information.

## Testing
- `npx --yes htmlhint index.html live-course.html practice.html contact.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b403e05d8c832486fe797a37c23401