### PR TITLE
Add simple home page with CSS styling

### DIFF
--- a/home.css
+++ b/home.css
@@ -1,0 +1,4 @@
+body{font-family:system-ui,Arial,sans-serif;max-width:800px;margin:40px auto;padding:0 16px;line-height:1.6}
+header{text-align:center;margin-bottom:32px}
+nav a{margin-right:12px;text-decoration:none}
+.features ul{list-style:disc;margin-left:20px}

--- a/home.html
+++ b/home.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Home - Affordable Maths Learning</title>
+  <link rel="stylesheet" href="home.css" />
+</head>
+<body>
+  <nav>
+    <a href="index.html">Landing</a>
+    <a href="live-course.html">Live Course</a>
+    <a href="practice.html">Practice</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+
+  <header>
+    <h1>Welcome to Our Maths Learning App</h1>
+    <p>Learn maths through recorded classes, live sessions and instant mentor support.</p>
+  </header>
+
+  <main>
+    <section class="features">
+      <h2>App Highlights</h2>
+      <ul>
+        <li>Hybrid learning with recorded and live classes.</li>
+        <li>Small group batches for personalised attention.</li>
+        <li>Instant tutor booking for quick doubt resolution.</li>
+        <li>Group study sessions guided by expert mentors.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `home.html` describing the maths learning app in brief
- include `home.css` for basic page styling and navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b43106737c8324a6415fb53eb7d565