### PR TITLE
Add Telegram link to contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -21,6 +21,7 @@
     </nav>
     <h1>Contact</h1>
     <p>Email us at <a href="mailto:you@yourdomain.com">you@yourdomain.com</a> to learn more.</p>
+    <p>Hey, join us on Telegram: <a href="https://t.me/padhado">t.me/padhado</a></p>
   </header>
   <footer>
     <p>© <span id="y"></span> Your Startup</p>


### PR DESCRIPTION
## Summary
- add Telegram channel link to Contact page

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b4391beea88324b8fed8c7e5743631