### PR TITLE
Simplify home page with Padhado overview

### DIFF
--- a/home.html
+++ b/home.html
@@ -3,32 +3,18 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Home - Affordable Maths Learning</title>
-  <link rel="stylesheet" href="home.css" />
+  <title>Padhado – Simple & Affordable Maths</title>
 </head>
 <body>
   <nav>
-    <a href="index.html">Landing</a>
+    <a href="index.html">Home</a>
     <a href="live-course.html">Live Course</a>
     <a href="practice.html">Practice</a>
     <a href="contact.html">Contact</a>
   </nav>
-
-  <header>
-    <h1>Welcome to Our Maths Learning App</h1>
-    <p>Learn maths through recorded classes, live sessions and instant mentor support.</p>
-  </header>
-
-  <main>
-    <section class="features">
-      <h2>App Highlights</h2>
-      <ul>
-        <li>Hybrid learning with recorded and live classes.</li>
-        <li>Small group batches for personalised attention.</li>
-        <li>Instant tutor booking for quick doubt resolution.</li>
-        <li>Group study sessions guided by expert mentors.</li>
-      </ul>
-    </section>
-  </main>
+  <h1>Padhado</h1>
+  <p>Padhado is an edtech platform dedicated to making mathematics simple and affordable for every student. We provide high-quality tutorials, theory videos, and practice question sets (PYQs) to strengthen conceptual understanding. Currently, we are offering free math courses on YouTube for Class 10 (State Board/CBSE), and students can easily access lessons anytime.</p>
+  <p>In December, we are launching our Instant Mentor Connect feature, which will allow students to connect with experienced mentors instantly for doubt-solving and personal guidance. With recorded courses, live sessions, and upcoming instant support, Padhado is building a complete online ecosystem for effective and accessible math learning.</p>
 </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -3,125 +3,18 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Your Startup – Affordable Maths Learning</title>
-  <meta name="description" content="Recorded + live maths classes at low cost. Instant booking & group mentoring." />
-  <style>
-    body{font-family:system-ui,Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.6}
-    header{margin-bottom:24px}
-    nav a{margin-right:12px;text-decoration:none}
-    a.button{display:inline-block;padding:10px 14px;border:1px solid #222;border-radius:8px;text-decoration:none}
-    table{width:100%;border-collapse:collapse;margin-top:16px}
-    th,td{border:1px solid #ddd;padding:8px;text-align:left}
-
-    footer{margin-top:32px;font-size:.9em;color:#666}
-  </style>
+  <title>Padhado – Simple & Affordable Maths</title>
 </head>
 <body>
-  <header>
-    <nav>
-      <a href="index.html">Home</a>
-      <a href="live-course.html">Live Course</a>
-      <a href="practice.html">Practice</a>
-      <a href="contact.html">Contact</a>
-    </nav>
-    <h1>Affordable Online Maths Learning</h1>
-    <p>Recorded classes, every 3rd class live, question practice + video solutions. Small batches (2/4/8), instant tutor booking.</p>
-    <a class="button" href="mailto:you@yourdomain.com">Contact Us</a>
-  </header>
-
-
-  <main>
-    <section id="summary">
-      <h2>Executive Summary</h2>
-      <p><strong>Startup Name:</strong> [Your Brand Name]</p>
-      <p><strong>Domain:</strong> <a href="http://www.yourdomain.com">www.yourdomain.com</a></p>
-      <p><strong>Mission Statement:</strong> To make high-quality mathematics education accessible and affordable for every student, using a flexible mix of recorded, live, and on-demand mentoring models.</p>
-      <p><strong>Vision:</strong> To become the most affordable and scalable online math learning platform, serving students across India and beyond.</p>
-    </section>
-
-    <section id="problem">
-      <h2>Problem Statement</h2>
-      <ul>
-        <li>High Cost of Quality Education: Private coaching and branded ed-tech platforms are expensive.</li>
-        <li>Lack of Flexibility: Students must choose between large generic classes or unaffordable 1-to-1 tutoring.</li>
-        <li>Accessibility Gaps: Rural and low-income students have limited access to quality mentors.</li>
-        <li>Immediate Doubt-Solving: No affordable platforms provide instant on-demand math help.</li>
-      </ul>
-    </section>
-
-    <section id="solution">
-      <h2>Solution / Product</h2>
-      <ul>
-        <li><strong>Hybrid Course (Recorded + Every 3rd Class Live)</strong>
-          <ul>
-            <li>Full recorded course library.</li>
-            <li>Every 3rd class is live for doubt resolution.</li>
-            <li>Practice questions with video solutions.</li>
-          </ul>
-        </li>
-        <li><strong>Batch-Based Courses</strong>
-          <ul>
-            <li>Same hybrid model with smaller live batches (2 / 4 / 8 students).</li>
-            <li>More personalized mentoring, lower cost per student.</li>
-          </ul>
-        </li>
-        <li><strong>Instant Teacher Booking</strong>
-          <ul>
-            <li>Students can instantly connect with a math tutor.</li>
-            <li>Flexible pay-per-minute model (₹6/minute).</li>
-          </ul>
-        </li>
-        <li><strong>Group Study + Mentor Guidance</strong>
-          <ul>
-            <li>Students form their own study groups (2, 4, or 8).</li>
-            <li>Guided by a mentor at a shared low cost.</li>
-          </ul>
-        </li>
-      </ul>
-    </section>
-
-    <section id="pricing">
-      <h2>Pricing Strategy</h2>
-      <table>
-        <thead>
-          <tr><th>Model</th><th>Offering</th><th>Price (per student)</th><th>Notes</th></tr>
-        </thead>
-        <tbody>
-          <tr><td>Hybrid Course</td><td>Recorded + every 3rd class live + practice + solutions</td><td>₹800 / year</td><td>Unlimited students, scalable model</td></tr>
-          <tr><td>Batch (2 students)</td><td>Hybrid in 2-student group</td><td>₹500 ÷ 2 = ₹250 / year</td><td>Most personalized</td></tr>
-          <tr><td>Batch (4 students)</td><td>Hybrid in 4-student group</td><td>₹500 ÷ 4 = ₹125 / year</td><td>Balanced option</td></tr>
-          <tr><td>Batch (8 students)</td><td>Hybrid in 8-student group</td><td>₹500 ÷ 8 = ₹62.5 / year</td><td>Most affordable</td></tr>
-          <tr><td>Instant Teacher Booking</td><td>Urgent doubt-solving</td><td>₹6 / minute</td><td>Pay-as-you-go</td></tr>
-          <tr><td>Group Study (2 students)</td><td>Mentor guidance in 2-student group</td><td>₹500 ÷ 2 = ₹250 per student</td><td>Premium personal attention</td></tr>
-          <tr><td>Group Study (4 students)</td><td>Mentor guidance in 4-student group</td><td>₹500 ÷ 4 = ₹125 per student</td><td>Mid-tier</td></tr>
-          <tr><td>Group Study (8 students)</td><td>Mentor guidance in 8-student group</td><td>₹500 ÷ 8 = ₹62.5 per student</td><td>Lowest-cost guided learning</td></tr>
-        </tbody>
-      </table>
-    </section>
-
-    <section id="revenue">
-      <h2>Revenue Model</h2>
-      <p>Multiple revenue streams:</p>
-      <ul>
-        <li>Subscription fees (₹800/year) from Hybrid courses (scalable at mass level).</li>
-        <li>Batch fees (2/4/8 students) for semi-personalized classes.</li>
-        <li>Instant booking charges (₹6/minute) for urgent help.</li>
-        <li>Group study session fees (₹500 split per group).</li>
-      </ul>
-    </section>
-  </main>
-
-  <section class="cards">
-    <div class="card"><h3>Hybrid Course</h3><p>₹800/year per student.</p></div>
-    <div class="card"><h3>Batch (2/4/8)</h3><p>₹500 ÷ batch size per year.</p></div>
-    <div class="card"><h3>Instant Booking</h3><p>₹6 per minute.</p></div>
-    <div class="card"><h3>Group Study</h3><p>₹500 ÷ group size per session.</p></div>
-  </section>
-
-
-  <footer>
-    <p>© <span id="y"></span> Your Startup • <a href="/privacy.html">Privacy</a> • <a href="/terms.html">Terms</a></p>
-  </footer>
-  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="live-course.html">Live Course</a>
+    <a href="practice.html">Practice</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+  <h1>Padhado</h1>
+  <p>Padhado is an edtech platform dedicated to making mathematics simple and affordable for every student. We provide high-quality tutorials, theory videos, and practice question sets (PYQs) to strengthen conceptual understanding. Currently, we are offering free math courses on YouTube for Class 10 (State Board/CBSE), and students can easily access lessons anytime.</p>
+  <p>In December, we are launching our Instant Mentor Connect feature, which will allow students to connect with experienced mentors instantly for doubt-solving and personal guidance. With recorded courses, live sessions, and upcoming instant support, Padhado is building a complete online ecosystem for effective and accessible math learning.</p>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Replace existing landing page content with a concise overview of Padhado
- Provide simple navigation links to other site sections

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b464f30f6c8324857cdcd1ec2c6659