### PR TITLE
Add quadratic equation video link to course page

### DIFF
--- a/live-course.html
+++ b/live-course.html
@@ -22,6 +22,11 @@
     <h1>Live Courses</h1>
     <p>Join our interactive live maths sessions to ask questions in real time and collaborate with classmates.</p>
   </header>
+  <section>
+    <h2>Quadratic Equation Lesson</h2>
+    <p>Watch our latest video on Quadratic Equations:</p>
+    <p><a href="https://www.youtube.com/watch?v=VIDEO_ID_HERE" target="_blank" rel="noopener">Quadratic Equation Explained</a></p>
+  </section>
   <footer>
     <p>© <span id="y"></span> Your Startup</p>
   </footer>


### PR DESCRIPTION
## Summary
- add section linking to a YouTube video on quadratic equations on the Live Courses page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4669d1b8c83249f38825534343b00