### PR TITLE
Send booking data to Gmail and Telegram

### DIFF
--- a/book.html
+++ b/book.html
@@ -17,30 +17,87 @@
     <h1>Book Your Mentor</h1>
     <p>Schedule a session with our mentors and get personalized guidance.</p>
   </header>
-  <section>
-    <form>
+  <section class="booking-section">
+    <form id="booking-form" class="form-card">
       <p>
         <label>Name:<br>
           <input type="text" name="name" required>
         </label>
       </p>
       <p>
-        <label>Email:<br>
-          <input type="email" name="email" required>
+        <label>Class:<br>
+          <select name="class" required>
+            <option value="">Select Class</option>
+            <option value="9">9th</option>
+            <option value="10">10th</option>
+          </select>
         </label>
       </p>
       <p>
-        <label>Preferred Date:<br>
-          <input type="date" name="date" required>
+        <label>Subject:<br>
+          <select name="subject" required>
+            <option value="">Select Subject</option>
+            <option value="Maths">Maths</option>
+            <option value="Science">Science</option>
+          </select>
+        </label>
+      </p>
+      <p>
+        <label>Phone:<br>
+          <input type="tel" name="phone" required>
         </label>
       </p>
       <button type="submit">Book Now</button>
     </form>
-    <p>After booking, join our Telegram for the latest Zoom code: <a href="https://t.me/padhado">t.me/padhado</a></p>
   </section>
   <footer>
     <p>© <span id="y"></span> Your Startup</p>
   </footer>
-  <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+  <script>
+    const BOT_TOKEN = 'YOUR_BOT_TOKEN'; // replace with your bot token
+    const CHAT_ID = 'YOUR_CHAT_ID';     // replace with your chat ID
+    const GROUP_LINK = 'https://t.me/padhado';
+
+    document.getElementById('booking-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const form = e.target;
+      const data = new FormData(form);
+      const message = `New booking:\nName: ${data.get('name')}\nClass: ${data.get('class')}\nSubject: ${data.get('subject')}\nPhone: ${data.get('phone')}`;
+      const emailPayload = {
+        name: data.get('name'),
+        class: data.get('class'),
+        subject: data.get('subject'),
+        phone: data.get('phone'),
+        _subject: 'New booking request'
+      };
+
+      try {
+        const emailRes = await fetch('https://formsubmit.co/ajax/padhado@gmail.com', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body: JSON.stringify(emailPayload)
+        });
+
+        const telegramRes = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ chat_id: CHAT_ID, text: message })
+        });
+
+        if (emailRes.ok && telegramRes.ok) {
+          window.location.href = GROUP_LINK;
+        } else {
+          alert('Failed to send booking.');
+        }
+      } catch {
+        alert('Failed to send booking.');
+      }
+    });
+
+    document.getElementById('y').textContent = new Date().getFullYear();
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -34,6 +34,47 @@ h1 {
   color: #0044cc;
 }
 
+.booking-section {
+  display: flex;
+  justify-content: center;
+}
+
+.form-card {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.form-card p {
+  margin-bottom: 15px;
+}
+
+.form-card input,
+.form-card select {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.form-card button {
+  width: 100%;
+  padding: 10px;
+  background: #28a745;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.form-card button:hover {
+  background: #218838;
+}
+
 .button {
   display: inline-block;
   padding: 10px 20px;


### PR DESCRIPTION
## Summary
- Send booking form submissions to padhado@gmail.com using FormSubmit
- Forward the same booking details to Telegram before redirecting to the group

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b53246b418832486f9634200a8999b