### PR TITLE
Add maths chapter video section and home page YouTube link

### DIFF
--- a/course.html
+++ b/course.html
@@ -39,6 +39,13 @@
       <a class="button" href="book.html">Book Now</a>
     </div>
   </section>
+  <section class="video-section">
+    <h2>Maths Chapters</h2>
+    <div class="video-card">
+      <h3>Quadratic Equations</h3>
+      <iframe src="https://www.youtube.com/embed/JkPlqvYZFoE" title="Quadratic Equations" allowfullscreen></iframe>
+    </div>
+  </section>
   <footer>
     <p>© <span id="y"></span> Your Startup</p>
   </footer>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <header>
+  <header class="hero">
     <nav>
       <a href="index.html">Home</a>
       <a href="course.html">Course</a>
@@ -19,6 +19,7 @@
     <p>Padhado is an edtech platform dedicated to making mathematics simple and affordable for every student. We provide high-quality tutorials, theory videos, and practice question sets (PYQs) to strengthen conceptual understanding. Currently, we are offering free math courses on YouTube for Class 10 (State Board/CBSE), and students can easily access lessons anytime.</p>
     <p>In December, we are launching our Instant Mentor Connect feature, which will allow students to connect with experienced mentors instantly for doubt-solving and personal guidance. With recorded courses, live sessions, and upcoming instant support, Padhado is building a complete online ecosystem for effective and accessible math learning.</p>
     <p><a class="button" href="https://t.me/padhado" target="_blank" rel="noopener">Connect with Mentor on Zoom Call</a></p>
+    <p><a class="button youtube" href="https://www.youtube.com/@padhado" target="_blank" rel="noopener">Visit our YouTube Channel</a></p>
   </header>
   <footer>
     <p>© <span id="y"></span> Your Startup</p>

--- a/style.css
+++ b/style.css
@@ -22,6 +22,23 @@ header {
   margin-bottom: 24px;
 }
 
+.hero {
+  background: linear-gradient(135deg, #6fb1fc, #4364f7);
+  color: #fff;
+  padding: 40px 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.hero h1 {
+  color: #fff;
+}
+
+.hero p {
+  margin: 0 auto 16px;
+  max-width: 700px;
+}
+
 nav a {
   color: #fff;
   margin: 0 12px;
@@ -91,6 +108,14 @@ h1 {
   background: #218838;
 }
 
+.button.youtube {
+  background: #ff0000;
+}
+
+.button.youtube:hover {
+  background: #cc0000;
+}
+
 footer {
   margin-top: 32px;
   font-size: 0.9em;
@@ -115,6 +140,35 @@ footer {
 .course-card h3 {
   color: #0044cc;
   margin-top: 0;
+}
+
+.video-section {
+  margin-top: 40px;
+}
+
+.video-section h2 {
+  text-align: center;
+  color: #0044cc;
+}
+
+.video-card {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.video-card h3 {
+  color: #0044cc;
+  margin-top: 0;
+}
+
+.video-card iframe {
+  width: 100%;
+  height: 315px;
+  border: none;
+  border-radius: 4px;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Add Maths Chapters video section to course page with embedded Quadratic Equations video
- Style video section for cohesive look with site
- Enhance home page with hero section and link to YouTube channel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b53db01e148324bfff2a0c6c868817