### PR TITLE
Replace alerts with toast and remove blue accents

### DIFF
--- a/book.html
+++ b/book.html
@@ -53,6 +53,7 @@
   <footer>
     <p>© <span id="y"></span> Your Startup</p>
   </footer>
+  <div id="toast" class="toast" aria-live="polite"></div>
   <script>
     const GROUP_LINK = 'https://t.me/padhado';
 
@@ -78,20 +79,27 @@
           },
           body: JSON.stringify(emailPayload)
         });
-
-
         if (emailRes.ok) {
-          window.location.href = GROUP_LINK;
-          alert('Booking sent!');
-          form.reset();
+          showToast('Booking sent!');
+          setTimeout(() => {
+            window.location.href = GROUP_LINK;
+            form.reset();
+          }, 1000);
         } else {
-          alert('Failed to send booking.');
+          showToast('Failed to send booking.');
         }
       } catch {
-        alert('Failed to send booking.');
+        showToast('Failed to send booking.');
       }
     });
-
+    function showToast(message) {
+      const toast = document.getElementById('toast');
+      toast.textContent = message;
+      toast.classList.add('show');
+      setTimeout(() => {
+        toast.classList.remove('show');
+      }, 3000);
+    }
     document.getElementById('y').textContent = new Date().getFullYear();
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@ body {
 }
 
 nav {
-  background: #0044cc;
+  background: #333;
   padding: 10px;
   border-radius: 4px;
   margin-bottom: 24px;
@@ -23,7 +23,7 @@ header {
 }
 
 .hero {
-  background: linear-gradient(135deg, #6fb1fc, #4364f7);
+  background: linear-gradient(135deg, #6fda44, #28a745);
   color: #fff;
   padding: 40px 20px;
   border-radius: 8px;
@@ -51,7 +51,7 @@ nav a:hover {
 
 h1 {
   text-align: center;
-  color: #0044cc;
+  color: #333;
 }
 
 .booking-section {
@@ -137,8 +137,9 @@ footer {
   text-align: center;
 }
 
+
 .course-card h3 {
-  color: #0044cc;
+  color: #333;
   margin-top: 0;
 }
 
@@ -146,9 +147,10 @@ footer {
   margin-top: 40px;
 }
 
+
 .video-section h2 {
   text-align: center;
-  color: #0044cc;
+  color: #333;
 }
 
 .video-card {
@@ -159,9 +161,33 @@ footer {
   text-align: center;
 }
 
+
 .video-card h3 {
-  color: #0044cc;
+  color: #333;
   margin-top: 0;
+}
+
+.toast {
+  visibility: hidden;
+  min-width: 200px;
+  margin-left: -100px;
+  background: #333;
+  color: #fff;
+  text-align: center;
+  border-radius: 4px;
+  padding: 10px;
+  position: fixed;
+  z-index: 1;
+  left: 50%;
+  bottom: 30px;
+  opacity: 0;
+  transition: opacity 0.5s, bottom 0.5s;
+}
+
+.toast.show {
+  visibility: visible;
+  opacity: 1;
+  bottom: 50px;
 }
 
 .video-card iframe {


### PR DESCRIPTION
## Summary
- Replace JavaScript alerts with custom toast notifications on booking page
- Remove blue color accents; switch navigation and headings to neutral palette and hero to green
- Add toast styling and utility function

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b548b37ec483249ab0ccec04cf734e