### PR TITLE
feat: replace blue theme with multicolor palette

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,11 +5,11 @@ body {
   padding: 0 16px;
   line-height: 1.6;
   background: #f8f9fa;
-  color: blue;
+  color: #333;
 }
 
 nav {
-  background: #333;
+  background: linear-gradient(90deg, #28a745, #ff9800);
   padding: 10px;
   border-radius: 4px;
   margin-bottom: 24px;
@@ -24,14 +24,14 @@ header {
 
 .hero {
   background: linear-gradient(135deg, #6fda44, #28a745);
-  color: blue;
+  color: #fff;
   padding: 40px 20px;
   border-radius: 8px;
   text-align: center;
 }
 
 .hero h1 {
-  color: blue;
+  color: #fff;
 }
 
 .hero p {
@@ -40,7 +40,7 @@ header {
 }
 
 nav a {
-  color: blue;
+  color: #fff;
   margin: 0 12px;
   text-decoration: none;
 }
@@ -51,7 +51,7 @@ nav a:hover {
 
 h1 {
   text-align: center;
-  color: blue;
+  color: #28a745;
 }
 
 .booking-section {
@@ -85,7 +85,7 @@ h1 {
   width: 100%;
   padding: 10px;
   background: #28a745;
-  color: blue;
+  color: #fff;
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -99,7 +99,7 @@ h1 {
   display: inline-block;
   padding: 10px 20px;
   background: #28a745;
-  color: blue;
+  color: #fff;
   text-decoration: none;
   border-radius: 4px;
 }
@@ -119,7 +119,7 @@ h1 {
 footer {
   margin-top: 32px;
   font-size: 0.9em;
-  color: blue;
+  color: #333;
   text-align: center;
 }
 
@@ -139,7 +139,7 @@ footer {
 
 
 .course-card h3 {
-  color: blue;
+  color: #28a745;
   margin-top: 0;
 }
 
@@ -150,7 +150,7 @@ footer {
 
 .video-section h2 {
   text-align: center;
-  color: blue;
+  color: #ff9800;
 }
 
 .video-card {
@@ -163,7 +163,7 @@ footer {
 
 
 .video-card h3 {
-  color: blue;
+  color: #28a745;
   margin-top: 0;
 }
 
@@ -172,7 +172,7 @@ footer {
   min-width: 200px;
   margin-left: -100px;
   background: #333;
-  color: blue;
+  color: #fff;
   text-align: center;
   border-radius: 4px;
   padding: 10px;


### PR DESCRIPTION
## Summary
- replace monotonous blue text with dark gray for better readability
- apply green-to-orange gradient in navigation and keep white accents
- highlight headings and cards with green and orange for more vibrant look

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b246fcc48324a0cb93c1b410b174